### PR TITLE
Moved pagination_meta method from the base controller to the base rep…

### DIFF
--- a/app/controllers/base_controller.py
+++ b/app/controllers/base_controller.py
@@ -1,6 +1,7 @@
 from app.utils.auth import Auth
 from flask import jsonify, make_response
 
+
 class BaseController:
 	
 	def __init__(self, request):
@@ -24,7 +25,6 @@ class BaseController:
 		for key in keys:
 			values.append(self.request.args.get(key))
 		return values
-		
 	
 	def get_json(self):
 		return self.request.get_json()
@@ -48,11 +48,3 @@ class BaseController:
 	
 	def missing_response(self, msg='Missing Required Parameters'):
 		return self.handle_response(msg=msg, status_code=400)
-	
-	def pagination_meta(self, paginator):
-		return {'total_rows': paginator.total, 'total_pages': paginator.pages, 'current_page': paginator.page,
-				'next_page': paginator.next_num, 'prev_page': paginator.prev_num}
-	
-	def prettify_response_dates(self, created_at, updated_at=None):
-		return {'created_at': created_at, 'updated_at': updated_at,
-				'date_pretty_short': created_at.strftime('%b %d, %Y'), 'date_pretty': created_at.strftime('%B %d, %Y')}

--- a/app/models/base_model.py
+++ b/app/models/base_model.py
@@ -1,9 +1,10 @@
 from app.utils import db
 from sqlalchemy import exc
 from datetime import datetime
-from app.utils import to_camel_case
 from sqlalchemy.inspection import inspect
 from app.repositories.base_repo import BaseRepo
+from app.utils import to_camel_case, format_response_timestamp
+
 
 class BaseModel(db.Model):
 	__abstract__ = True
@@ -23,10 +24,9 @@ class BaseModel(db.Model):
 	def delete(self):
 		db.session.delete(self)
 		db.session.commit()
-		
+	
 	def serialize(self):
 		s = {to_camel_case(column.name): getattr(self, column.name) for column in self.__table__.columns if column.name not in ['created_at', 'updated_at']}
-		s['timestamps'] = {'created_at': self.created_at, 'updated_at': self.updated_at, 'date_pretty_short': self.created_at.strftime('%b %d, %Y'),
-						   'date_pretty': self.created_at.strftime('%B %d, %Y')}
+		s['timestamps'] = {'createdAt': format_response_timestamp(self.created_at), 'updatedAt': format_response_timestamp(self.updated_at)}
 		return s
 

--- a/app/repositories/base_repo.py
+++ b/app/repositories/base_repo.py
@@ -8,7 +8,6 @@ class BaseRepo:
 		"""Return all the data in the model."""
 		return self._model.query.paginate(error_out=False)
 	
-	
 	def get(self, *args):
 		"""Return data by the Id."""
 		return self._model.query.get(*args)
@@ -20,54 +19,46 @@ class BaseRepo:
 		model_instance.save()
 		return model_instance
 	
-	
 	def count(self):
 		"""Return the count of all the data in the model."""
 		return self._model.query.count()
-	
 	
 	def get_first_item(self):
 		"""Return the first data in the model."""
 		return self._model.query.first()
 	
-	
 	def order_by(self, *args):
 		"""Query and order the data of the model."""
 		return self._model.query.order_by(*args)
-	
 	
 	def filter_all(self, **kwargs):
 		"""Query and filter the data of the model."""
 		return self._model.query.filter(**kwargs).paginate(error_out=False)
 	
-	
 	def filter_by(self, **kwargs):
 		"""Query and filter the data of the model."""
 		return self._model.query.filter_by(**kwargs).paginate(error_out=False)
-	
 	
 	def find_first(self, **kwargs):
 		"""Query and filter the data of a model, returning the first result."""
 		return self._model.query.filter_by(**kwargs).first()
 	
-	
 	def filter_and_count(self, **kwargs):
 		"""Query, filter and counts all the data of a model."""
 		return self._model.query.filter_by(**kwargs).count()
-	
 	
 	def filter_and_order(self, *args, **kwargs):
 		"""Query, filter and orders all the data of a model."""
 		return self._model.query.filter_by(**kwargs).order_by(*args)
 	
-	
 	def paginate(self, **kwargs):
 		"""Query and paginate the data of a model, returning the first result."""
 		return self._model.query.paginate(**kwargs)
 	
-	
 	def filter(self, *args):
 		"""Query and filter the data of the model."""
 		return self._model.query.filter(*args)
-
 	
+	def pagination_meta(self, paginator):
+		return {'totalRows': paginator.total, 'totalPages': paginator.pages, 'currentPage': paginator.page,
+				'nextPage': paginator.next_num, 'prevPage': paginator.prev_num}

--- a/app/utils/__init__.py
+++ b/app/utils/__init__.py
@@ -1,11 +1,20 @@
 from flask_sqlalchemy import SQLAlchemy
+from datetime import datetime
 
 db = SQLAlchemy()
 
+
 def to_camel_case(snake_str):
-    """Format string to camel case."""
-    title_str = snake_str.title().replace("_", "")
-    return title_str[0].lower() + title_str[1:]
+	"""Format string to camel case."""
+	title_str = snake_str.title().replace("_", "")
+	return title_str[0].lower() + title_str[1:]
+
 
 def to_pascal_case(word, sep='_'):
 	return ''.join(list(map(lambda x: x.capitalize(), word.split(sep))))
+
+
+def format_response_timestamp(date_obj):
+	if isinstance(date_obj, datetime):
+		return {'isoDate': date_obj.isoformat(), 'datePretty': date_obj,
+				'datePrettyShort': date_obj.strftime('%b %d, %Y')}


### PR DESCRIPTION
Moved `pagination_meta()` method from the `base_controller` to the `base_repo`. 
Seems natural for all data access and manipulation to be with the repo rather than the controller.

Removed `prettify_response_dates()` method. A more generic method was created in the utils file.

Model `serialize()` method made to return all camel cased field names.